### PR TITLE
Fix empty menu bug

### DIFF
--- a/app/components/nav/_AppNav.js
+++ b/app/components/nav/_AppNav.js
@@ -8,6 +8,9 @@ import _ from 'lodash';
 class AppNav extends  React.Component{
 
 	render(){
+		if (!this.props.menu)
+			return null;
+		
 		let { items } = this.props.menu;
 		items = _.sortBy(items, 'order');
 


### PR DESCRIPTION
Avoid red screen with bug report for clean/new Wordpress installations (due to empty nav menu).